### PR TITLE
Fix keyboard not responding after USB wake from sleep

### DIFF
--- a/tide75/linker/wireless/transport.c
+++ b/tide75/linker/wireless/transport.c
@@ -120,15 +120,21 @@ void usb_remote_wakeup(void) {
     }
 #else
     static uint32_t suspend_timer = 0x00;
+    static bool suspended = false;
 
     if ((USB_DRIVER.state == USB_SUSPENDED)) {
         if (!suspend_timer) suspend_timer = sync_timer_read32();
         if (sync_timer_elapsed32(suspend_timer) >= USB_POWER_DOWN_DELAY) {
             suspend_timer = 0x00;
+            suspended = true;
             suspend_power_down();
         }
     } else {
         suspend_timer = 0x00;
+        if (suspended) {
+            suspended = false;
+            suspend_wakeup_init();
+        }
     }
 #endif
 }


### PR DESCRIPTION
## Summary

- **Bug**: Keyboard becomes unresponsive after the host computer wakes from sleep when connected via USB. Users must unplug and replug the cable to restore functionality.
- **Root cause**: In `usb_remote_wakeup()` (non-`USB_REMOTE_USE_QMK` path), `suspend_power_down()` is called when USB enters suspended state, but `suspend_wakeup_init()` is never called when USB returns to active — leaving keyboard subsystems (matrix scanning, etc.) in a shut-down state.
- **Fix**: Track suspend state with a `bool` flag and call `suspend_wakeup_init()` on resume, matching the pattern used in QMK's own suspend handling.

## Test plan

- [x] Built firmware successfully from the [hangshengkeji/qmk_firmware](https://github.com/hangshengkeji/qmk_firmware/tree/tri-mode) fork (which shares this same `linker/wireless/transport.c` code)
- [x] Flashed to Epomaker Tide75 keyboard
- [x] Verified keyboard responds correctly after host wakes from sleep (previously required unplug/replug)
- [x] Verified normal USB operation is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)