### PR TITLE
Add explicit debounce of 5ms to fix double keypress issue

### DIFF
--- a/tide75/info.json
+++ b/tide75/info.json
@@ -6,6 +6,7 @@
     "bootmagic": {
         "matrix": [0, 0]
     },
+    "debounce": 5,
     "diode_direction": "ROW2COL",
     "encoder": {
         "rotary": [


### PR DESCRIPTION
## Summary
- The shipped firmware (from hangshengkeji/qmk_firmware) sets debounce to 1ms, which is far too low to filter mechanical switch contact bounce (typically 5-15ms), causing intermittent double key registrations
- Adds an explicit `"debounce": 5` to `info.json` to match the QMK recommended default and prevent the issue from recurring in future builds
- Verified fix resolves double keypress on physical TIDE 75 hardware

## Test plan
- [x] Flashed firmware with debounce set to 5ms on TIDE 75 hardware
- [x] Confirmed double keypress issue is resolved across all keys
- [ ] Maintainer verification on additional TIDE 75 units

🤖 Generated with [Claude Code](https://claude.com/claude-code)